### PR TITLE
Removed php-etl/metadata-contracts from the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "doctrine/inflector": "^2.0",
         "php-etl/metadata": "^0.2.0",
         "php-etl/mapping-contracts": "^0.2.0",
-        "php-etl/metadata-contracts": "^0.1.0",
         "php-etl/satellite-toolbox": "^0.1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e47e32183796f760b5cbf5e324746f2",
+    "content-hash": "e7f86a31a5dab1ba2177fdf29f66d860",
     "packages": [
         {
             "name": "doctrine/inflector",


### PR DESCRIPTION
Ce package a été supprimé du composer.json car il est require dans metadata.