### PR TITLE
Enabled several types (boolean, int, string) for the constant mapper

### DIFF
--- a/src/Mapping/Field/ConstantValueMapper.php
+++ b/src/Mapping/Field/ConstantValueMapper.php
@@ -47,9 +47,30 @@ final class ConstantValueMapper implements
             new Node\Stmt\Expression(
                 new Node\Expr\Assign(
                     $outputNode,
-                    new Node\Scalar\String_($this->value)
+                    $this->compileValue($this->value)
                 ),
             ),
         ];
+    }
+
+    public function compileValue(mixed $value): Node\Expr
+    {
+        if ($value === true) {
+            return new Node\Expr\ConstFetch(
+                name: new Node\Name(name: 'true'),
+            );
+        }
+
+        if ($value === false) {
+            return new Node\Expr\ConstFetch(
+                name: new Node\Name(name: 'false'),
+            );
+        }
+
+        if (is_int($value)) {
+            return new Node\Scalar\LNumber(value: $value);
+        }
+
+        return new Node\Scalar\String_(value: $value);
     }
 }


### PR DESCRIPTION
Pour le `ConstantValueMapper`, j'ai ajouté de nouveaux types pouvant être utilisés : 
1. bool
2. int
3. string (de base)