### PR TITLE
Enabled null type for the constant mapper

### DIFF
--- a/src/Mapping/Field/ConstantValueMapper.php
+++ b/src/Mapping/Field/ConstantValueMapper.php
@@ -67,6 +67,12 @@ final class ConstantValueMapper implements
             );
         }
 
+        if (is_null($value)) {
+            return new Node\Expr\ConstFetch(
+                name: new Node\Name(name: 'null'),
+            );
+        }
+
         if (is_int($value)) {
             return new Node\Scalar\LNumber(value: $value);
         }


### PR DESCRIPTION
Le ConstantMapper devrait prendre un compte le type `null`.

![image](https://user-images.githubusercontent.com/47692802/166955057-2772c8fd-90e9-48df-82de-1b9ca391a2bc.png)
